### PR TITLE
Fix crash on launch caused by null reference exception

### DIFF
--- a/Apphangar/src/main/java/ca/mimic/apphangar/AppsRowAdapter.java
+++ b/Apphangar/src/main/java/ca/mimic/apphangar/AppsRowAdapter.java
@@ -99,7 +99,7 @@ public class AppsRowAdapter extends BaseAdapter {
         if (completeRedraw) {
             holder.taskIcon.setImageBitmap(null);
         }
-        if (!ih.cachedIconHelper(holder.taskIcon, rowItem.getComponentName())) {
+        if (rowItem.getComponentName() == null || !ih.cachedIconHelper(holder.taskIcon, rowItem.getComponentName())) {
             mRowItems.remove(rowItem);
         }
         holder.taskIcon.setContentDescription(rowItem.getName());


### PR DESCRIPTION
Hangar was working fine until I installed an app that caused the rowItem.getComponentName() to return null. This fix allows Hangar to still function. 